### PR TITLE
Fix geojson-stream integration

### DIFF
--- a/bin/geojson-polygon-labels
+++ b/bin/geojson-polygon-labels
@@ -94,7 +94,9 @@ if (includeMinzoom && typeof includeMinzoom === "string" && includeMinzoom.split
 function polylabelStream() {
     return Combiner(geojsonStream.parse(),
         through(function (feature, callback) {
-            this.queue(labelFeature(feature));
+            labelFeature(feature).forEach((feature) => {
+                this.queue(feature);
+            })
         }),
         geojsonStream.stringify());
 }
@@ -106,6 +108,7 @@ inputStream
 
 function labelFeature(inputFeature) {
     featureCount++;
+    let labeledFeatures = [];
     process.stderr.write('...' + featureCount + "\r");
 
     if (inputFeature.geometry) {
@@ -183,8 +186,7 @@ function labelFeature(inputFeature) {
                 if (tippecanoeProperties) {
                     labelFeature.tippecanoe = tippecanoeProperties;
                 }
-                console.log(labelFeature)
-                return labelFeature;
+                labeledFeatures.push(labelFeature);
             }else{
                 if (feature.geometry) {
                     // warn the users that non Polygon features are ignored
@@ -197,6 +199,8 @@ function labelFeature(inputFeature) {
             }
         });
     }
+
+    return labeledFeatures;
 }
 
 function areaToZoom(area, min, max) {


### PR DESCRIPTION
@andrewharvey I'm brand new to JSON streams, so I apologize if this is an improper approach. This seems to work on my sample geojson multipolygon and polygon data. I would greatly appreciate your feedback.

I was able to recreate the issue you referenced https://github.com/andrewharvey/geojson-polygon-labels/issues/7#issuecomment-463830696 where exploding multipolygons did not work. The challenge was that when the `labelFeature` function received a single feature, it would sometimes result in multiple label features.

My approach: within `labelFeature`, push each label to an array of labeledFeatures. The labeledFeatures array gets returned to the `through` function. There, we loop through the labeledFeatures and run `this.queue` for each label.